### PR TITLE
checksum_cb -> checksum. rework send_poll and recv_poll to handle nul…

### DIFF
--- a/functional_tests/ack_one_message.cpp
+++ b/functional_tests/ack_one_message.cpp
@@ -9,7 +9,7 @@ TEST(functional, ack_one_message)
     cfg.segment_length_in_bytes = 128;
     cfg.message_length_in_segments = 4;
     cfg.retransmission_timeout = 100;
-    cfg.checksum_cb = &arq_crc32;
+    cfg.checksum = &arq_crc32;
 
     ArqContext sender(cfg), receiver(cfg);
 

--- a/functional_tests/recv_10mb_through_window.cpp
+++ b/functional_tests/recv_10mb_through_window.cpp
@@ -8,7 +8,7 @@ TEST(functional, recv_10mb_through_window)
     cfg.segment_length_in_bytes = 220;
     cfg.message_length_in_segments = 4;
     cfg.retransmission_timeout = 100;
-    cfg.checksum_cb = &arq_crc32;
+    cfg.checksum = &arq_crc32;
 
     ArqContext ctx(cfg);
 
@@ -30,6 +30,7 @@ TEST(functional, recv_10mb_through_window)
     while (test_output.size() < test_input.size()) {
         while (ctx.arq.recv_wnd.w.size < ctx.arq.recv_wnd.w.cap) {
             for (int seg = 0; seg < cfg.message_length_in_segments; ++seg) {
+                h.seg = 1;
                 h.seg_len = arq__min(cfg.segment_length_in_bytes, test_input.size() - test_input_offset);
                 h.seg_id = seg;
 

--- a/functional_tests/recv_full_window.cpp
+++ b/functional_tests/recv_full_window.cpp
@@ -8,7 +8,7 @@ TEST(functional, recv_full_window)
     cfg.segment_length_in_bytes = 220;
     cfg.message_length_in_segments = 4;
     cfg.retransmission_timeout = 100;
-    cfg.checksum_cb = &arq_crc32;
+    cfg.checksum = &arq_crc32;
 
     ArqContext ctx(cfg);
 
@@ -31,6 +31,7 @@ TEST(functional, recv_full_window)
 
     size_t test_input_offset = 0;
     while (test_input_offset < test_input.size()) {
+        h.seg = 1;
         h.seg_len = arq__min(cfg.segment_length_in_bytes, test_input.size() - test_input_offset);
         frame.resize(arq__frame_len(h.seg_len));
 

--- a/functional_tests/send_10mb_through_window.cpp
+++ b/functional_tests/send_10mb_through_window.cpp
@@ -8,7 +8,7 @@ TEST(functional, send_10mb_through_window)
     cfg.segment_length_in_bytes = 220;
     cfg.message_length_in_segments = 4;
     cfg.retransmission_timeout = 100;
-    cfg.checksum_cb = &arq_crc32;
+    cfg.checksum = &arq_crc32;
 
     ArqContext ctx(cfg);
 
@@ -76,7 +76,7 @@ TEST(functional, send_10mb_through_window)
                     arq__frame_hdr_t h;
                     arq__frame_read_result_t const r = arq__frame_read(frame.data(),
                                                                        frame_len,
-                                                                       cfg.checksum_cb,
+                                                                       cfg.checksum,
                                                                        &h,
                                                                        (void const **)&seg);
                     CHECK_EQUAL(ARQ__FRAME_READ_RESULT_SUCCESS, r);

--- a/functional_tests/send_full_window.cpp
+++ b/functional_tests/send_full_window.cpp
@@ -8,7 +8,7 @@ TEST(functional, send_full_window)
     cfg.segment_length_in_bytes = 220;
     cfg.message_length_in_segments = 4;
     cfg.retransmission_timeout = 100;
-    cfg.checksum_cb = &arq_crc32;
+    cfg.checksum = &arq_crc32;
 
     ArqContext ctx(cfg);
 
@@ -52,7 +52,7 @@ TEST(functional, send_full_window)
             void const *seg;
             arq__frame_hdr_t h;
             arq__frame_read_result_t const r =
-                arq__frame_read(decode_buf, size, cfg.checksum_cb, &h, &seg);
+                arq__frame_read(decode_buf, size, cfg.checksum, &h, &seg);
             CHECK_EQUAL(ARQ__FRAME_READ_RESULT_SUCCESS, r);
             recv_test_data.insert(std::end(recv_test_data),
                                   (unsigned char const *)seg,

--- a/functional_tests/transfer_10mb_one_way_manual_acks.cpp
+++ b/functional_tests/transfer_10mb_one_way_manual_acks.cpp
@@ -9,7 +9,7 @@ TEST(functional, transfer_10mb_one_way_manual_acks)
     cfg.segment_length_in_bytes = 220;
     cfg.message_length_in_segments = 4;
     cfg.retransmission_timeout = 100;
-    cfg.checksum_cb = &arq_crc32;
+    cfg.checksum = &arq_crc32;
 
     ArqContext sender(cfg), receiver(cfg);
 
@@ -80,7 +80,7 @@ TEST(functional, transfer_10mb_one_way_manual_acks)
                 void const *seg;
                 arq__frame_hdr_t h;
                 arq__frame_read_result_t const r =
-                    arq__frame_read(decode.data(), frame_len, cfg.checksum_cb, &h, &seg);
+                    arq__frame_read(decode.data(), frame_len, cfg.checksum, &h, &seg);
                 CHECK(ARQ_SUCCEEDED(r));
                 unsigned const ack_vec = (1 << (h.seg_id + 1)) - 1u;
                 arq__send_wnd_ack(&sender.arq.send_wnd, h.seq_num, ack_vec);

--- a/functional_tests/transfer_full_window_one_way.cpp
+++ b/functional_tests/transfer_full_window_one_way.cpp
@@ -9,7 +9,7 @@ TEST(functional, transfer_full_window_one_way_manual_acks)
     config.segment_length_in_bytes = 220;
     config.message_length_in_segments = 4;
     config.retransmission_timeout = 100;
-    config.checksum_cb = &arq_crc32;
+    config.checksum = &arq_crc32;
 
     ArqContext sender(config), receiver(config);
 

--- a/unit_tests/test_frame.cpp
+++ b/unit_tests/test_frame.cpp
@@ -65,7 +65,7 @@ int MockArqFrameSegWrite(void const *seg, void *out_buf, int len)
         .returnIntValue();
 }
 
-void MockArqFrameChecksumWrite(arq_checksum_cb_t checksum, void *checksum_seat, void *frame, int seg_len)
+void MockArqFrameChecksumWrite(arq_checksum_t checksum, void *checksum_seat, void *frame, int seg_len)
 {
     mock().actualCall("arq__frame_checksum_write")
         .withParameter("checksum", (void *)checksum)
@@ -88,7 +88,7 @@ void MockArqFrameHdrRead(void const *buf, arq__frame_hdr_t *out_frame_hdr)
 arq__frame_read_result_t MockArqFrameChecksumRead(void const *frame,
                                                   int frame_len,
                                                   int seg_len,
-                                                  arq_checksum_cb_t checksum)
+                                                  arq_checksum_t checksum)
 {
     return (arq__frame_read_result_t)mock().actualCall("arq__frame_checksum_read")
                                            .withParameter("frame", frame)


### PR DESCRIPTION
…l send headers, meaning there's nothing to emit. fix lots of logic problems due to window management being too closely coupled to frame availability. fix functional tests. respect seg and ack flags from headers.