### PR TITLE
rewrite arq__send_wnd_send() to precompute and iterate over the numbe…

### DIFF
--- a/functional_tests/CMakeLists.txt
+++ b/functional_tests/CMakeLists.txt
@@ -23,7 +23,8 @@ set(ARQ_FUNCTIONAL_TEST_SOURCES main.cpp
                                 transfer_10mb_one_way_manual_acks.cpp
                                 ack_one_message.cpp
                                 ack_full_window.cpp
-                                poll_until_tinygram_sends.cpp)
+                                poll_until_tinygram_sends.cpp
+                                tiny_sends_accumulate_into_message.cpp)
 
 string(REPLACE ";" " " ARQ_RUNTIME_FLAGS_STR "${ARQ_RUNTIME_FLAGS}")
 set_source_files_properties(arq_in_test_project.c PROPERTIES COMPILE_FLAGS "${ARQ_RUNTIME_FLAGS_STR}")

--- a/functional_tests/tiny_sends_accumulate_into_message.cpp
+++ b/functional_tests/tiny_sends_accumulate_into_message.cpp
@@ -1,0 +1,69 @@
+#include "functional_tests.h"
+
+namespace {
+
+TEST(functional, tiny_sends_accumulate_into_message)
+{
+    arq_cfg_t cfg;
+    cfg.segment_length_in_bytes = 220;
+    cfg.message_length_in_segments = 4;
+    cfg.retransmission_timeout = 1000;
+    cfg.tinygram_send_delay = cfg.segment_length_in_bytes;
+    cfg.checksum = &arq_crc32;
+    ArqContext ctx(cfg);
+
+    std::vector< arq_uchar_t > send_test_data(cfg.segment_length_in_bytes - 1);
+    for (auto i = 0u; i < send_test_data.size() / 2; ++i) {
+        arq_uint16_t x = (arq_uint16_t)i * 2;
+        std::memcpy(&send_test_data[i * 2], &x, sizeof(x));
+    }
+
+    for (auto i = 0u; i < cfg.tinygram_send_delay - 1; ++i) {
+        {
+            int sent;
+            arq_err_t const e = arq_send(&ctx.arq, &send_test_data[i], 1, &sent);
+            CHECK(ARQ_SUCCEEDED(e));
+            CHECK_EQUAL(1, sent);
+        }
+
+        {
+            arq_event_t event;
+            arq_time_t next_poll;
+            int bytes_to_drain;
+            arq_err_t const e = arq_backend_poll(&ctx.arq, 1, &bytes_to_drain, &event, &next_poll);
+            CHECK(ARQ_SUCCEEDED(e));
+            CHECK_EQUAL(0, bytes_to_drain);
+        }
+    }
+
+    {
+        arq_event_t event;
+        arq_time_t next_poll;
+        int bytes_to_drain;
+        arq_err_t const e = arq_backend_poll(&ctx.arq, 1, &bytes_to_drain, &event, &next_poll);
+        CHECK(ARQ_SUCCEEDED(e));
+        CHECK(bytes_to_drain);
+    }
+
+    int size;
+    arq_uchar_t decode_buf[256];
+    {
+        void const *p;
+        arq_err_t e = arq_backend_send_ptr_get(&ctx.arq, &p, &size);
+        CHECK_EQUAL(ARQ_OK_COMPLETED, e);
+        std::memcpy(decode_buf, p, size);
+        e = arq_backend_send_ptr_release(&ctx.arq);
+        CHECK_EQUAL(ARQ_OK_COMPLETED, e);
+    }
+
+    {
+        void const *seg;
+        arq__frame_hdr_t h;
+        arq__frame_read_result_t const r = arq__frame_read(decode_buf, size, cfg.checksum, &h, &seg);
+        CHECK_EQUAL(ARQ__FRAME_READ_RESULT_SUCCESS, r);
+        MEMCMP_EQUAL(send_test_data.data(), seg, send_test_data.size());
+    }
+}
+
+}
+


### PR DESCRIPTION
…r of newly-filled messages, making it easier to track tinygram rtx.